### PR TITLE
Turn off highlight for new searches and confirm substitution

### DIFF
--- a/plugin/searchlight.vim
+++ b/plugin/searchlight.vim
@@ -77,7 +77,7 @@ function! s:update()
   let s:timer = 0
   silent! call matchdelete(get(w:, 'searchlight_id', -1))
 
-  if !v:hlsearch || @/ == '' || !s:enable
+  if !v:hlsearch || @/ == '' || !s:enable || mode() == 'r'
     return
   endif
 

--- a/plugin/searchlight.vim
+++ b/plugin/searchlight.vim
@@ -42,7 +42,7 @@ function s:start()
       autocmd CursorMoved,WinEnter,CmdlineLeave * call <SID>update()
     endif
     autocmd InsertLeave * call <SID>update()
-    autocmd InsertEnter,WinLeave * call <SID>clear()
+    autocmd InsertEnter,WinLeave,CmdlineEnter * call <SID>clear()
   augroup END
   call s:trigger()
 endfunction


### PR DESCRIPTION
Two separate fixes for two issues: #1 and leftover highlights from :s///c. Can split into two PRs if you want.

Figured I'd just fix it instead of opening another issue. 