### PR TITLE
Catch malformed regular expression errors

### DIFF
--- a/plugin/searchlight.vim
+++ b/plugin/searchlight.vim
@@ -89,7 +89,12 @@ function! s:update()
     let top = max([1, pos[0] - context])
     let bottom = pos[0] + context
 
-    let start = searchpos(@/, 'bc', top, timeout)
+    try
+      let start = searchpos(@/, 'bc', top, timeout)
+    catch /^Vim\%((\a\+)\)\=:E/
+      return
+    endtry
+
     if start == [0, 0]
       return
     endif


### PR DESCRIPTION
If the user-entered regular expression is malformed (for example, `\()`,
which has an unmatched parenthesis), this call to `searchpos()` would
blow up with a Vim exception and stack trace message.

This change wraps this call in `try..catch` to produce a friendlier user
experience. The Vim error (e.g. `E54: Unmatched \("`) is still displayed
to the user, but the plugin code itself exits safely.