### PR TITLE
Add requirement of set hlsearch on instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Vim-searchlight highlights Vim's current search match.
 
 Searchlight requires Vim 8+ with timer support. It is tested on Vim 8.1.
 
+> Make sure you have `set hlsearch` on your ~/.vimrc
+
 ## Experimental
 
 Searchlight is an experiment. Your mileage my vary. Might not work with other plugins or your `vimrc`.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ Vim-searchlight highlights Vim's current search match.
 
 ## Requirements
 
-Searchlight requires Vim 8+ with timer support. It is tested on Vim 8.1.
+Searchlight requires `'hsearch'` to be active and Vim 8+ with timer support. It is tested on Vim 8.1.
 
-> Make sure you have `set hlsearch` on your ~/.vimrc
 
 ## Experimental
 

--- a/doc/searchlight.txt
+++ b/doc/searchlight.txt
@@ -11,8 +11,9 @@ Searchlight = Search + Highlight
 Highlights the current search match.
 
 1. Commands		|searchlight-commands|
-2. Customization	|searchlight-customization|
-3. Issues		|searchlight-issues|
+2. Requirements		|searchlight-requirements|
+3. Customization	|searchlight-customization|
+4. Issues		|searchlight-issues|
 
 ==============================================================================
 1. Searchlight commands                             *searchlight-commands*
@@ -22,7 +23,15 @@ Highlights the current search match.
 :Searchlight!	Disable Searchlight
 
 ==============================================================================
-2. Searchlight customization                       *searchlight-customization*
+2. Searchlight requirements                       *searchlight-requirements*
+
+Searchlight requires |'hlsearch'| to be active and |+timer| support. >
+
+	set hlsearch
+<
+
+==============================================================================
+3. Searchlight customization                       *searchlight-customization*
 
                                                               *hl-Searchlight*
 Searchlight uses the |hl-Searchlight| group to highlight the current match.
@@ -43,7 +52,7 @@ activating on startup. Defaults to 0. >
 	let g:searchlight_disable_on_startup = 1
 <
 ==============================================================================
-3. Known Issues                                            *searchlight-issues*
+4. Known Issues                                            *searchlight-issues*
 
 When using any search command like: "*" (|star|), |#|, etc at the beginning of
 a match and it is the only match, then searchlight will not trigger.


### PR DESCRIPTION
@PeterRincker thanks for this great plugin!

I've struggled a bit to get it working and before setting `hlsearch` I wasn't able to see any highlights at all.

Feel free to adjust copy.

Hoping this tip would become useful to others in the future.

Keep Rocking!